### PR TITLE
fix: use of $IP in function scope needs global

### DIFF
--- a/ShibAuthPlugin.php
+++ b/ShibAuthPlugin.php
@@ -346,6 +346,7 @@ function ShibAutoAuthenticate(&$user) {
 /* Tries to be magical about when to log in users and when not to. */
 function ShibUserLoadFromSession($user, &$result)
 {
+        global $IP;
         global $wgContLang;
         global $wgAuth;
         global $shib_UN;


### PR DESCRIPTION
I'm sorry, I somehow missed this line in yesterday's patch.
