### PR TITLE
Added $shib_group_delete flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ $shib_email = isset($_SERVER['HTTP_EMAIL']) ? $_SERVER['HTTP_EMAIL'] : null;
 $shib_groups = isset($_SERVER['isMemberOf']) ? $_SERVER['isMemberOf'] : null;
 $shib_group_prefix = "wiki";
 
+// Should pre-existing groups be deleted?
+// If groups are fetched only from Shibboleth it should be true
+// if memberships are granted from mediawiki User rights management
+// page, it should be false
+// PLEASE NOTE: with $shib_group_delete = false, in order to revoke
+// a membership it should be deleted both from Shibboleth and 
+// User rights management page!
+$shib_group_delete = false;
+
 // The ShibUpdateUser hook is executed on login.
 // It has two arguments:
 // - $existing: True if this is an existing user, false if it is a new user being added

--- a/ShibAuthPlugin.php
+++ b/ShibAuthPlugin.php
@@ -469,11 +469,14 @@ function ShibUserLoadFromSession($user, &$result)
 function ShibAddGroups($user) {
 	global $shib_groups;
 	global $shib_group_prefix;
+	global $shib_group_delete;
 
-	$oldGroups = $user->getGroups();
-        foreach ($oldGroups as $group) {
-                $user->removeGroup($group);
-        }
+	if (isset($shib_group_delete) && $shib_group_delete) {
+		$oldGroups = $user->getGroups();
+        	foreach ($oldGroups as $group) {
+                	$user->removeGroup($group);
+        	}
+	}
 
 	if (isset($shib_groups)) {
 		foreach (explode(';', $shib_groups) as $group) {


### PR DESCRIPTION
This patch addresses issue #6.
A new flag is introduced to enable automatic membership deletion ruled by shibboleth.
If this feature is not what you want, just set $shib_group_delete=false;
